### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,6 +1,7 @@
 {
   "source-url": "git@github.com:yowcow/p6-WebService-SOP.git",
   "name": "WebService::SOP",
+  "license" : "Artistic-2.0",
   "test-depends": [
     "Test",
     "Test::META"


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license