### PR TITLE
Fixes for forthcoming release of URI

### DIFF
--- a/lib/WebService/SOP/V1_1/Request/DELETE.pm6
+++ b/lib/WebService/SOP/V1_1/Request/DELETE.pm6
@@ -10,7 +10,7 @@ method create-request(URI :$uri, Hash:D :$params, Str:D :$app-secret --> HTTP::R
 
     die '`time` is required in params' if not $params<time>:exists;
 
-    my %query = %( $uri.query-form, %$params );
+    my %query = %( $uri.query-form.Hash, %$params );
     %query<sig> = create-signature(%query, $app-secret);
 
     DELETE(URI.new("{$uri.scheme}://{$uri.host}{$uri.path}?{build-query-string(%query)}"));

--- a/lib/WebService/SOP/V1_1/Request/GET.pm6
+++ b/lib/WebService/SOP/V1_1/Request/GET.pm6
@@ -10,7 +10,7 @@ method create-request(URI :$uri, Hash:D :$params, Str:D :$app-secret --> HTTP::R
 
     die '`time` is required in params' if not $params<time>:exists;
 
-    my %query = %( $uri.query-form, %$params );
+    my %query = %( $uri.query-form.Hash, %$params );
     %query<sig> = create-signature(%query, $app-secret);
 
     GET(URI.new("{$uri.scheme}://{$uri.host}{$uri.path}?{build-query-string(%query)}"));

--- a/lib/WebService/SOP/V1_1/Request/POST.pm6
+++ b/lib/WebService/SOP/V1_1/Request/POST.pm6
@@ -9,7 +9,7 @@ method create-request(URI :$uri, Hash:D :$params, Str:D :$app-secret --> HTTP::R
 
     die '`time` is required in params' if not $params<time>:exists;
 
-    my %query = %( $uri.query-form, %$params );
+    my %query = %( $uri.query-form.Hash, %$params );
     %query<sig> = create-signature(%query, $app-secret);
 
     POST(

--- a/lib/WebService/SOP/V1_1/Request/POST_JSON.pm6
+++ b/lib/WebService/SOP/V1_1/Request/POST_JSON.pm6
@@ -10,7 +10,7 @@ method create-request(URI :$uri, Hash:D :$params, Str:D :$app-secret --> HTTP::R
 
     die '`time` is required in params' if not $params<time>:exists;
 
-    my Str $json-data = to-json(%( $uri.query-form, %$params ), pretty => False);
+    my Str $json-data = to-json(%( $uri.query-form.Hash, %$params ), pretty => False);
     my Str $sig = create-signature($json-data, $app-secret);
 
     POST(

--- a/lib/WebService/SOP/V1_1/Request/PUT.pm6
+++ b/lib/WebService/SOP/V1_1/Request/PUT.pm6
@@ -9,7 +9,7 @@ method create-request(URI :$uri, Hash:D :$params, Str:D :$app-secret --> HTTP::R
 
     die '`time` is required in params' if not $params<time>:exists;
 
-    my %query = %( $uri.query-form, %$params );
+    my %query = %( $uri.query-form.Hash, %$params );
     %query<sig> = create-signature(%query, $app-secret);
 
     PUT(

--- a/lib/WebService/SOP/V1_1/Request/PUT_JSON.pm6
+++ b/lib/WebService/SOP/V1_1/Request/PUT_JSON.pm6
@@ -10,7 +10,7 @@ method create-request(URI :$uri, Hash:D :$params, Str:D :$app-secret --> HTTP::R
 
     die '`time` is required in params' if not $params<time>:exists;
 
-    my Str $json-data = to-json(%( $uri.query-form, %$params ), pretty => False);
+    my Str $json-data = to-json(%( $uri.query-form.Hash, %$params ), pretty => False);
     my Str $sig = create-signature($json-data, $app-secret);
 
     PUT(

--- a/lib/WebService/SOP/V1_1/Util.pm6
+++ b/lib/WebService/SOP/V1_1/Util.pm6
@@ -12,7 +12,7 @@ our sub stringify-params(%params --> Str) {
     %params.keys.sort.grep({ $_ !~~ m{^^ sop_ } })
         .map({
 
-            die "Only Stringy or Numeric is acceptable for values"
+            die "Only Stringy or Numeric is acceptable for values { $_ } - { %params.perl } - { %params{$_}.perl }"
                 if not (%params{$_} ~~ Stringy || %params{$_} ~~ Numeric);
 
             $_ ~ '=' ~ %params{$_}

--- a/t/03-client.t
+++ b/t/03-client.t
@@ -83,9 +83,9 @@ subtest {
         is $req.uri.scheme, 'http';
         is $req.uri.host,   'hoge';
         is $req.uri.path,   '/fuga';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
-        my %query = URI::split-query(~$req.content);
+        my %query = URI::split-query(~$req.content).Hash;
 
         is %query<app_id>,  123;
         is %query<aaa>,     'aaa';
@@ -104,7 +104,7 @@ subtest {
         is $req.uri.scheme, 'http';
         is $req.uri.host,   'hoge';
         is $req.uri.path,   '/fuga';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         like ~$req.header.field('X-Sop-Sig'), rx{ ^^ <[a..f 0..9]> ** 64 $$ };
 
@@ -123,7 +123,7 @@ subtest {
         );
 
         is $req.method, 'PUT';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         my %query = URI::split-query(~$req.content);
 
@@ -141,7 +141,7 @@ subtest {
         );
 
         is $req.method, 'PUT';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         like ~$req.header.field('X-Sop-Sig'), rx{ ^^ <[a..f 0..9]> ** 64 $$ };
 

--- a/t/request/post.t
+++ b/t/request/post.t
@@ -42,7 +42,7 @@ subtest {
         is $req.uri.host,   'hoge';
         is $req.uri.path,   '/fuga';
         is $req.header.field('Content-Type'), 'application/x-www-form-urlencoded';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         my %query = URI::split-query(~$req.content);
 
@@ -67,7 +67,7 @@ subtest {
         is $req.uri.host,   'hoge';
         is $req.uri.path,   '/fuga';
         is $req.header.field('Content-Type'), 'application/x-www-form-urlencoded';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         my %query = URI::split-query(~$req.content);
 

--- a/t/request/put.t
+++ b/t/request/put.t
@@ -42,7 +42,7 @@ subtest {
         is $req.uri.host,   'hoge';
         is $req.uri.path,   '/fuga';
         is $req.header.field('Content-Type'), 'application/x-www-form-urlencoded';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         my %query = URI::split-query(~$req.content);
 
@@ -67,7 +67,7 @@ subtest {
         is $req.uri.host,   'hoge';
         is $req.uri.path,   '/fuga';
         is $req.header.field('Content-Type'), 'application/x-www-form-urlencoded';
-        is-deeply $req.uri.query-form, {};
+        is-deeply $req.uri.query-form.Hash, {};
 
         my %query = URI::split-query(~$req.content);
 


### PR DESCRIPTION
This is to deal with changes in the https://github.com/perl6-community-modules/uri/pull/44
which is planned to be released this week.  The only real changes are
that the query is now an object and needs to be coerced to a Hash in one
or two places.

I've tested with both as-is and forthcoming versions of URI to ensure it
works with both (the coercions will be a no-op in the as-is version)